### PR TITLE
Add missing cstdint include for explicit template instantiations

### DIFF
--- a/src/include/gpuntt/common/common.cuh
+++ b/src/include/gpuntt/common/common.cuh
@@ -9,6 +9,7 @@
 #include <cuda_runtime.h>
 
 #include <cassert>
+#include <cstdint>
 #include <exception>
 #include <iostream>
 #include <string>


### PR DESCRIPTION
Dear maintainers,

 I encountered a minor issue in my [cuFHEpp](https://github.com/virtualsecureplatform/cuFHEpp.git) compilation so this PR fixes that.

common.cu uses std::int32_t, std::uint64_t etc. in explicit template instantiations, but common.cuh (which it includes) did not include <cstdint>, causing compilation failures with some compilers.

Thank you for sharing your great work in the library form!